### PR TITLE
Incrementing the version of lombok, as this resolves the constructor issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <modelmapper.version>2.1.1</modelmapper.version>
-    <lombok.version>1.18.0</lombok.version>
+    <lombok.version>1.18.2</lombok.version>
     <testng.version>6.9.10</testng.version>
   </properties>
   <licenses>


### PR DESCRIPTION
As per this comment [#1347](https://github.com/rzwitserloot/lombok/issues/1347#issuecomment-415290315) this issue is resolved in 1.18.2 release of lombok.

There still exist issues with lombok's @Builder.Default annotation but since in our case Jsr310ModuleConfig class does not have a manually defined constructor hence , just a version upgrade should fix the issue.

I have verified this on my end. Please review and let me know your comments. Thanks.
 